### PR TITLE
增加爬取阵容推荐功能，创建一个HttpProvider的静态管理类，采用单例模式确保全局只有一个 HttpClient 实例，允许项目中的…

### DIFF
--- a/SourceCode/JinChanChanTool/DataClass/MetatftLineupDtos.cs
+++ b/SourceCode/JinChanChanTool/DataClass/MetatftLineupDtos.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace JinChanChanTool.DataClass
+{
+    // 元数据 (Metadata) 相关模型 
+
+    public class CompsDataResponse
+    {
+        [JsonPropertyName("results")]
+        public CompsDataResults Results { get; set; }
+    }
+
+    public class CompsDataResults
+    {
+        [JsonPropertyName("data")]
+        public CompsDataDetail Data { get; set; }
+    }
+
+    public class CompsDataDetail
+    {
+        [JsonPropertyName("cluster_details")]
+        public Dictionary<string, ClusterDetail> ClusterDetails { get; set; }
+    }
+
+    public class ClusterDetail
+    {
+        [JsonPropertyName("Cluster")]
+        public int Cluster { get; set; }
+
+        [JsonPropertyName("name")]
+        public List<CompNameItem> Name { get; set; }
+
+        [JsonPropertyName("units_string")]
+        public string UnitsString { get; set; }
+
+        [JsonPropertyName("builds")]
+        public List<CompBuildInfo> Builds { get; set; }
+    }
+
+    public class CompBuildInfo
+    {
+        [JsonPropertyName("unit")]
+        public string Unit { get; set; }
+
+        [JsonPropertyName("buildName")]
+        public List<string> BuildName { get; set; }
+    }
+
+    // 实时统计 (Stats) 相关模型
+
+    public class CompsStatsResponse
+    {
+        [JsonPropertyName("results")]
+        public List<CompStatResult> Results { get; set; }
+    }
+
+    public class CompStatResult
+    {
+        [JsonPropertyName("cluster")]
+        public string Cluster { get; set; }
+
+        [JsonPropertyName("places")]
+        public List<int> Places { get; set; }
+
+        [JsonPropertyName("count")]
+        public int Count { get; set; }
+    }
+
+    // 阵容详情与站位 (Details) 相关模型 
+
+    public class CompDetailsResponse
+    {
+        [JsonPropertyName("results")]
+        public CompDetailsResults Results { get; set; }
+    }
+
+    public class CompDetailsResults
+    {
+        [JsonPropertyName("proComps")]
+        public List<ProCompEntry> ProComps { get; set; }
+
+        [JsonPropertyName("positioning")]
+        public PositioningData Positioning { get; set; }
+    }
+
+    public class ProCompEntry
+    {
+        [JsonPropertyName("content")]
+        public ProCompContent Content { get; set; }
+    }
+
+    public class ProCompContent
+    {
+        [JsonPropertyName("content")]
+        public ProCompInnerContent InnerContent { get; set; }
+    }
+
+    public class ProCompInnerContent
+    {
+        [JsonPropertyName("titleImages")]
+        public List<TitleImage> TitleImages { get; set; }
+    }
+
+    public class TitleImage
+    {
+        [JsonPropertyName("apiName")]
+        public string ApiName { get; set; }
+    }
+
+    public class PositioningData
+    {
+        [JsonPropertyName("units")]
+        public Dictionary<string, UnitPositioning> Units { get; set; }
+    }
+
+    public class UnitPositioning
+    {
+        [JsonPropertyName("positions")]
+        public List<CellCount> Positions { get; set; }
+    }
+
+    public class CellCount
+    {
+        [JsonPropertyName("cell")]
+        public string Cell { get; set; }
+
+        [JsonPropertyName("count")]
+        public int Count { get; set; }
+    }
+
+    // 通用翻译 (zh_cn.json) 相关模型 
+
+    public class MetatftGeneralTranslation
+    {
+        [JsonPropertyName("common")]
+        public Dictionary<string, string> Common { get; set; }
+    }
+
+    public class CompNameItem
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// 类型：unit 代表英雄，trait 代表羁绊
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+        
+    }
+}

--- a/SourceCode/JinChanChanTool/Forms/NecessaryForm/MainForm.Designer.cs
+++ b/SourceCode/JinChanChanTool/Forms/NecessaryForm/MainForm.Designer.cs
@@ -58,6 +58,7 @@ namespace JinChanChanTool
             label_赛季 = new Label();
             toolTipTimer = new System.Windows.Forms.Timer(components);
             timer_UpdateCoordinates = new System.Windows.Forms.Timer(components);
+            更新阵容推荐ToolStripMenuItem = new ToolStripMenuItem();
             panel_SubLineUpParent.SuspendLayout();
             menuStrip_Main.SuspendLayout();
             panel_BackGround.SuspendLayout();
@@ -231,14 +232,14 @@ namespace JinChanChanTool
             button_Refresh.UseVisualStyleBackColor = true;
             button_Refresh.Click += button_Refresh_Click;
             // 
-            // comboBox_LineUps
+            // comboBox_SelectedLineUp
             // 
             comboBox_SelectedLineUp.Font = new Font("Microsoft YaHei UI", 9F, FontStyle.Regular, GraphicsUnit.Point, 134);
             comboBox_SelectedLineUp.FormattingEnabled = true;
             comboBox_SelectedLineUp.Items.AddRange(new object[] { "阵容1", "阵容2", "阵容3", "阵容4", "阵容5", "阵容6", "阵容7", "阵容8", "阵容9", "阵容10" });
             comboBox_SelectedLineUp.Location = new Point(242, 68);
             comboBox_SelectedLineUp.Margin = new Padding(2, 5, 2, 5);
-            comboBox_SelectedLineUp.Name = "comboBox_LineUps";
+            comboBox_SelectedLineUp.Name = "comboBox_SelectedLineUp";
             comboBox_SelectedLineUp.Size = new Size(149, 25);
             comboBox_SelectedLineUp.TabIndex = 1;
             comboBox_SelectedLineUp.Text = "阵容1";
@@ -246,7 +247,7 @@ namespace JinChanChanTool
             comboBox_SelectedLineUp.KeyDown += comboBox_LineUps_KeyDown;
             comboBox_SelectedLineUp.Leave += comboBox_LineUps_Leave;
             // 
-            // comboBox_HeroPool
+            // comboBox_Season
             // 
             comboBox_Season.DropDownStyle = ComboBoxStyle.DropDownList;
             comboBox_Season.Font = new Font("Microsoft YaHei UI", 9F, FontStyle.Regular, GraphicsUnit.Point, 134);
@@ -254,7 +255,7 @@ namespace JinChanChanTool
             comboBox_Season.Items.AddRange(new object[] { "巨龙之牙", "符文之地" });
             comboBox_Season.Location = new Point(239, 5);
             comboBox_Season.Margin = new Padding(2, 5, 2, 5);
-            comboBox_Season.Name = "comboBox_HeroPool";
+            comboBox_Season.Name = "comboBox_Season";
             comboBox_Season.Size = new Size(149, 25);
             comboBox_Season.TabIndex = 8;
             // 
@@ -262,7 +263,7 @@ namespace JinChanChanTool
             // 
             menuStrip_Main.BackColor = Color.White;
             menuStrip_Main.ImageScalingSize = new Size(24, 24);
-            menuStrip_Main.Items.AddRange(new ToolStripItem[] { toolStripMenuItem_设置, toolStripMenuItem_帮助, toolStripMenuItem_关于 });
+            menuStrip_Main.Items.AddRange(new ToolStripItem[] { toolStripMenuItem_设置, toolStripMenuItem_帮助, toolStripMenuItem_关于, 更新阵容推荐ToolStripMenuItem });
             menuStrip_Main.Location = new Point(3, 2);
             menuStrip_Main.Name = "menuStrip_Main";
             menuStrip_Main.Size = new Size(401, 25);
@@ -368,6 +369,13 @@ namespace JinChanChanTool
             timer_UpdateCoordinates.Interval = 1000;
             timer_UpdateCoordinates.Tick += timer_UpdateCoordinates_Tick;
             // 
+            // 更新阵容推荐ToolStripMenuItem
+            // 
+            更新阵容推荐ToolStripMenuItem.Name = "更新阵容推荐ToolStripMenuItem";
+            更新阵容推荐ToolStripMenuItem.Size = new Size(92, 21);
+            更新阵容推荐ToolStripMenuItem.Text = "更新阵容推荐";
+            更新阵容推荐ToolStripMenuItem.Click += 更新阵容推荐ToolStripMenuItem_Click;
+            // 
             // MainForm
             // 
             AutoScaleDimensions = new SizeF(96F, 96F);
@@ -421,5 +429,6 @@ namespace JinChanChanTool
         private Button button_变阵1;
         private Button button_变阵3;
         private Button button_变阵2;
+        private ToolStripMenuItem 更新阵容推荐ToolStripMenuItem;
     }
 }

--- a/SourceCode/JinChanChanTool/Program.cs
+++ b/SourceCode/JinChanChanTool/Program.cs
@@ -1,6 +1,8 @@
 using JinChanChanTool.Forms;
 using JinChanChanTool.Services.DataServices;
 using JinChanChanTool.Services.DataServices.Interface;
+using JinChanChanTool.Services.LineupCrawling;
+using JinChanChanTool.Services.LineupCrawling.Interface;
 using JinChanChanTool.Services.RecommendedEquipment;
 using JinChanChanTool.Services.RecommendedEquipment.Interface;
 using System.Diagnostics;
@@ -53,6 +55,15 @@ namespace JinChanChanTool
             _iLineUpService.SetFilePathsIndex(_iAutomaticSettingsService.CurrentConfig.SelectedSeason);
             _iLineUpService.Load();
 
+            //创建动态游戏数据服务
+            IDynamicGameDataService _iDynamicGameDataService = new DynamicGameDataService();
+
+            //创建装备爬取服务
+            ICrawlingService _iCrawlingService = new CrawlingService(_iDynamicGameDataService);
+
+            //创建阵容爬取服务
+            ILineupCrawlingService _iLineupCrawlingService = new LineupCrawlingService(_iDynamicGameDataService);
+
             // 创建并加载英雄装备推荐数据服务
             IHeroEquipmentDataService _iHeroEquipmentDataService = new HeroEquipmentDataService();
             _iHeroEquipmentDataService.Load();
@@ -63,7 +74,7 @@ namespace JinChanChanTool
             _iRecommendedLineUpService.Load();
 
             // 运行主窗体并传入应用设置服务
-            Application.Run(new MainForm(_iManualSettingsService,_iAutomaticSettingsService, _iheroDataService, _iEquipmentService,  _iCorrectionService, _iLineUpService, _iHeroEquipmentDataService, _iRecommendedLineUpService));
+            Application.Run(new MainForm(_iManualSettingsService,_iAutomaticSettingsService, _iheroDataService, _iEquipmentService,  _iCorrectionService, _iLineUpService, _iHeroEquipmentDataService, _iRecommendedLineUpService, _iDynamicGameDataService, _iCrawlingService, _iLineupCrawlingService));
         }
     }
 }

--- a/SourceCode/JinChanChanTool/Services/LineupCrawling/Interface/ILineupCrawlingService.cs
+++ b/SourceCode/JinChanChanTool/Services/LineupCrawling/Interface/ILineupCrawlingService.cs
@@ -1,0 +1,25 @@
+﻿using JinChanChanTool.DataClass;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace JinChanChanTool.Services.LineupCrawling.Interface
+{
+    /// <summary>
+    /// 阵容推荐爬取服务接口。
+    /// 负责从远程服务器抓取、解析并计算最新的阵容数据。
+    /// </summary>
+    public interface ILineupCrawlingService
+    {
+        /// <summary>
+        /// 异步执行完整的阵容数据爬取流程。
+        /// 包含元数据获取、实时统计计算、阵容详情抓取以及标签站位解析。
+        /// </summary>
+        /// <param name="progress">用于向UI反馈进度的对象 (百分比, 当前操作描述)。</param>
+        /// <returns>
+        /// 一个表示异步操作的任务。
+        /// 任务结果是包含所有解析后的阵容对象列表 (List<RecommendedLineUp>)。
+        /// </returns>
+        Task<List<RecommendedLineUp>> GetRecommendedLineUpsAsync(IProgress<Tuple<int, string>> progress);
+    }
+}

--- a/SourceCode/JinChanChanTool/Services/LineupCrawling/LineupCrawlingService.cs
+++ b/SourceCode/JinChanChanTool/Services/LineupCrawling/LineupCrawlingService.cs
@@ -1,0 +1,432 @@
+﻿using JinChanChanTool.DataClass;
+using JinChanChanTool.Forms;
+using JinChanChanTool.Services.LineupCrawling.Interface;
+using JinChanChanTool.Services.RecommendedEquipment.Interface;
+using JinChanChanTool.Services.Network;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace JinChanChanTool.Services.LineupCrawling
+{
+    /// <summary>
+    /// 核心阵容爬取服务。
+    /// 包含爬取流、Tier评分算法、标签清洗以及站位坐标转换。
+    /// </summary>
+    public class LineupCrawlingService : ILineupCrawlingService
+    {
+        private readonly IDynamicGameDataService _gameDataService;
+
+        /// <summary>
+        /// 临时存储阵容ID与英雄API Key列表的映射，用于站位精准匹配
+        /// </summary>
+        private readonly ConcurrentDictionary<string, List<string>> _clusterHeroKeysMap = new();
+
+        // API 路由常量
+        private const string MetadataUrl = "https://api-hc.metatft.com/tft-comps-api/comps_data?queue=1100";
+        private const string StatsUrl = "https://api-hc.metatft.com/tft-comps-api/comps_stats?queue=1100&patch=current&days=1&rank=CHALLENGER,DIAMOND,GRANDMASTER,MASTER&permit_filter_adjustment=true";
+        private const string DetailUrlBase = "https://api-hc.metatft.com/tft-comps-api/comp_details?comp={0}&cluster_id={1}";
+
+        public LineupCrawlingService(IDynamicGameDataService gameDataService)
+        {
+            _gameDataService = gameDataService;
+        }
+
+
+
+        /// <summary>
+        ///  执行三步爬取逻辑。
+        /// </summary>
+        public async Task<List<RecommendedLineUp>> GetRecommendedLineUpsAsync(IProgress<Tuple<int, string>> progress)
+        {
+            _clusterHeroKeysMap.Clear();
+
+            try
+            {
+                //  获取元数据 (Metadata)
+                progress?.Report(Tuple.Create(10, "正在获取阵容基础数据..."));
+                var metadata = await FetchMetadataAsync();
+                if (metadata == null || !metadata.Any()) return new List<RecommendedLineUp>();
+
+                //  获取统计数据 (Stats) 并计算评分
+                progress?.Report(Tuple.Create(30, "正在获取实时统计并计算评级..."));
+                var initialLineups = await FetchAndCalculateStatsAsync(metadata);
+                if (!initialLineups.Any()) return new List<RecommendedLineUp>();
+
+                // 获取阵容详情 (Tags & Positioning)
+                // 筛选出评分较好的阵容进行详情抓取（或者全量抓取）
+                progress?.Report(Tuple.Create(50, "正在获取阵容标签与站位详情..."));
+                var finalLineups = await FetchLineupDetailsAsync(initialLineups, progress);
+
+                progress?.Report(Tuple.Create(100, "阵容数据处理完毕！"));
+                return finalLineups;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"阵容爬取流程发生严重错误: {ex.Message}");
+                return new List<RecommendedLineUp>();
+            }
+        }
+
+        #region 元数据处理
+        private async Task<List<RecommendedLineUp>> FetchMetadataAsync()
+        {
+            using var response = await HttpProvider.Client.GetAsync(MetadataUrl, HttpCompletionOption.ResponseContentRead);
+            if (!response.IsSuccessStatusCode) return null;
+
+            var json = await response.Content.ReadAsStringAsync();
+            var data = JsonSerializer.Deserialize<CompsDataResponse>(json);
+            var results = new List<RecommendedLineUp>();
+
+            if (data?.Results?.Data?.ClusterDetails == null) return null;
+
+            foreach (var kvp in data.Results.Data.ClusterDetails)
+            {
+                var detail = kvp.Value;
+                var lineup = new RecommendedLineUp
+                {
+                    // 调用TranslateLineupName
+                    LineUpName = TranslateLineupName(detail.Name),
+                    Description = kvp.Key // 暂时存 ClusterID 方便后续匹配
+                };
+
+                // 处理 Units 和装备
+                var unitKeys = detail.UnitsString.Split(new[] { ", " }, StringSplitOptions.RemoveEmptyEntries).ToList();
+                _clusterHeroKeysMap[kvp.Key] = unitKeys;
+                foreach (var uKey in unitKeys)
+                {
+                    string heroName = _gameDataService.HeroTranslations.GetValueOrDefault(uKey, uKey);
+
+                    // 匹配该棋子的推荐装备
+                    var build = detail.Builds?.FirstOrDefault(b => b.Unit == uKey);
+                    string[] equips = ["", "", ""];
+                    if (build?.BuildName != null)
+                    {
+                        for (int i = 0; i < Math.Min(3, build.BuildName.Count); i++)
+                        {
+                            equips[i] = _gameDataService.ItemTranslations.GetValueOrDefault(build.BuildName[i], build.BuildName[i]);
+                        }
+                    }
+                    lineup.LineUpUnits.Add(new LineUpUnit(heroName, equips[0], equips[1], equips[2]));
+                }
+                results.Add(lineup);
+            }
+            return results;
+        }
+
+        private string TranslateLineupName(List<CompNameItem> nameItems)
+        {
+            if (nameItems == null || !nameItems.Any()) return "未知阵容";
+
+            var nameParts = nameItems.Select(item =>
+            {
+                // 根据 DTO 中的 Type 字段精准匹配字典
+                if (item.Type == "unit")
+                    return _gameDataService.HeroTranslations.GetValueOrDefault(item.Name, item.Name);
+                if (item.Type == "trait")
+                    return _gameDataService.TraitTranslations.GetValueOrDefault(item.Name, item.Name);
+
+                return item.Name; // 兜底返回原名
+            });
+
+            return string.Join(" ", nameParts);
+        }
+        #endregion
+
+        #region 统计计算逻辑
+        private async Task<List<RecommendedLineUp>> FetchAndCalculateStatsAsync(List<RecommendedLineUp> metadata)
+        {
+            using var response = await HttpProvider.Client.GetAsync(StatsUrl, HttpCompletionOption.ResponseContentRead);
+            if (!response.IsSuccessStatusCode) return metadata;
+
+            var json = await response.Content.ReadAsStringAsync();
+            var stats = JsonSerializer.Deserialize<CompsStatsResponse>(json);
+            if (stats?.Results == null || stats.Results.Count == 0) return metadata;
+
+            // 分母: 总对局数
+            double totalMatches = stats.Results[0].Places.FirstOrDefault();
+            if (totalMatches <= 0) return metadata;
+
+            var processedList = new List<RecommendedLineUp>();
+
+            foreach (var lineup in metadata)
+            {
+                var stat = stats.Results.FirstOrDefault(s => s.Cluster == lineup.Description); // Description 存的是 ClusterID
+                if (stat == null || stat.Count == 0) continue;
+
+                double compCount = stat.Count;
+
+                // 1. 平均名次 (Avg Rank) - 索引 0-7
+                double weightedSum = 0;
+                for (int i = 0; i < 8; i++)
+                {
+                    weightedSum += stat.Places[i] * (i + 1);
+                }
+                lineup.AverageRank = Math.Round(weightedSum / compCount, 2);
+
+                // 2. 胜率 (Win Rate)
+                lineup.WinRate = Math.Round((stat.Places[0] / compCount) * 100, 2);
+
+                // 3. 前四率 (Top 4 Rate)
+                double top4Count = stat.Places.Take(4).Sum();
+                lineup.TopFourRate = Math.Round((top4Count / compCount) * 100, 2);
+
+                // 4. 选择率 (Pick Rate) - 这里计算用于评分的比率值
+                double pickRateRatio = (compCount / totalMatches) * 8;
+                lineup.PickRate = Math.Round(pickRateRatio * 100, 2);
+
+                // 5. 评级 (Tier) 计算
+                double score = lineup.AverageRank - (1.6 * pickRateRatio);
+                lineup.Tier = CalculateTier(score);
+
+                processedList.Add(lineup);
+            }
+
+            return processedList;
+        }
+
+        private LineUpTier CalculateTier(double score)
+        {
+            if (score < 3.85) return LineUpTier.S;
+            if (score < 4.15) return LineUpTier.A;
+            if (score < 4.45) return LineUpTier.B;
+            if (score < 5.00) return LineUpTier.C;
+            return LineUpTier.D;
+        }
+        #endregion
+
+        #region 详情、标签与站位转换
+        private async Task<List<RecommendedLineUp>> FetchLineupDetailsAsync(List<RecommendedLineUp> lineups, IProgress<Tuple<int, string>> progress)
+        {
+            const int MAX_CONCURRENT = 10; // 并发数 10
+            var semaphore = new SemaphoreSlim(MAX_CONCURRENT);
+            var tasks = new List<Task>();
+            var results = new ConcurrentBag<RecommendedLineUp>();
+            int count = 0;
+
+            foreach (var lineup in lineups)
+            {
+                await semaphore.WaitAsync();
+                tasks.Add(Task.Run(async () =>
+                {
+                    try
+                    {
+                        string clusterId = lineup.Description; // 获取原始ID
+                        string url = string.Format(DetailUrlBase, clusterId, clusterId.Substring(0, 3));
+
+                        using var response = await HttpProvider.Client.GetAsync(url, HttpCompletionOption.ResponseContentRead);
+                        if (response.IsSuccessStatusCode)
+                        {
+                            var json = await response.Content.ReadAsStringAsync();
+                            var detail = JsonSerializer.Deserialize<CompDetailsResponse>(json);
+
+                            if (detail?.Results != null)
+                            {
+                                // 解析标签
+                                lineup.Tags = ProcessTags(detail.Results);
+                                // 解析并打印站位
+                                ProcessPositioning(lineup.LineUpName, detail.Results.Positioning, lineup.LineUpUnits, clusterId);
+                            }
+                        }
+                        lineup.Description = ""; // 清空 ID
+                        results.Add(lineup);
+                    }
+                    catch (Exception ex) { Debug.WriteLine($"详情抓取失败: {ex.Message}"); }
+                    finally
+                    {
+                        Interlocked.Increment(ref count);
+                        progress?.Report(Tuple.Create(50 + (int)((double)count / lineups.Count * 50), $"正在处理详情: {lineup.LineUpName}"));
+                        semaphore.Release();
+                    }
+                }));
+            }
+
+            await Task.WhenAll(tasks);
+            return results.OrderBy(l => l.Tier).ThenByDescending(l => l.WinRate).ToList();
+        }
+
+        private List<string> ProcessTags(CompDetailsResults results)
+        {
+            var tags = new List<string>();
+            if (results.ProComps == null || results.ProComps.Count < 2) return tags;
+
+            var titleImages = results.ProComps[1].Content?.InnerContent?.TitleImages;
+            if (titleImages == null) return tags;
+
+            foreach (var img in titleImages)
+            {
+                string raw = img.ApiName;
+                if (string.IsNullOrEmpty(raw)) continue;
+
+                // 阵容标签中莫名出现这个，直接过滤（这个是暗裔之镰），不翻译也不填充
+                if (raw == "TFT16_TheDarkinScythe") continue;
+
+                // 1. 处理 Reroll 特殊标签
+                if (raw.Contains("Reroll"))
+                {
+                    if (raw.Contains("78")) tags.Add("7/8级d牌");
+                    else if (raw.Contains("6")) tags.Add("6级d牌");
+                    else if (raw.Contains("5")) tags.Add("5级d牌");
+                    continue;
+                }
+
+                // 2. 清洗后缀并翻译
+                string key = raw.Replace("TFT_Custom_Econ_", "")
+                                .Replace("TFT_Custom_Difficulty_", "")
+                                .Replace("_", " ");
+
+                key = Regex.Replace(key, @"Fast(\d+)", "Fast $1");
+
+                string translated = _gameDataService.CommonTranslations.GetValueOrDefault(key, key);
+                tags.Add(translated);
+            }
+            return tags;
+        }
+
+        /// <summary>
+        /// 使用匈牙利算法解决全局最优站位分布问题
+        /// </summary>
+        private void ProcessPositioning(string lineupName, PositioningData data, List<LineUpUnit> units, string clusterId)
+        {
+            if (data?.Units == null || !_clusterHeroKeysMap.TryGetValue(clusterId, out var heroKeys)) return;
+
+            int numHeroes = Math.Min(units.Count, heroKeys.Count);
+            const int numCells = 28; // 棋盘总格数
+
+            // 1. 构建代价矩阵 [英雄数量 x 28个格子]
+            double[,] costMatrix = new double[numHeroes, numCells];
+
+            for (int i = 0; i < numHeroes; i++)
+            {
+                string apiKey = heroKeys[i];
+                if (data.Units.TryGetValue(apiKey, out var posInfo))
+                {
+                    // 计算该英雄的总样本数用于归一化概率
+                    double totalCount = posInfo.Positions.Sum(p => p.Count);
+
+                    // 预填一个极大的代价（代表英雄从未去过的格子）
+                    for (int j = 0; j < numCells; j++) costMatrix[i, j] = 999.0;
+
+                    foreach (var pos in posInfo.Positions)
+                    {
+                        if (int.TryParse(pos.Cell.Replace("cell_", ""), out int cellId) && cellId >= 1 && cellId <= 28)
+                        {
+                            double prob = pos.Count / totalCount;
+                            // 代价函数：Cost = -log(P)，加个极小值防止log(0)
+                            costMatrix[i, cellId - 1] = -Math.Log(prob + 1e-9);
+                        }
+                    }
+                }
+            }
+
+            // 2. 调用匈牙利算法求解最小权重指派
+            int[] assignment = SolveHungarian(costMatrix, numHeroes, numCells);
+
+            // 3. 解析结果并打印输出
+            Debug.WriteLine($"\n--- 全局最优站位分布 (指派算法): {lineupName} ---");
+            LogTool.Log($"--- 全局最优站位分布: {lineupName} ---");
+
+            for (int i = 0; i < numHeroes; i++)
+            {
+                int cellId = assignment[i] + 1; // 索引转回 cell_ID
+                if (cellId > 0)
+                {
+                    // 坐标转换公式
+                    int row = 4 - (cellId - 1) / 7;
+                    int col = (cellId - 1) % 7 + 1;
+
+                    string heroName = units[i].HeroName;
+                    Debug.WriteLine($"棋子: {heroName.PadRight(6)} | 分配格: cell_{cellId.ToString().PadRight(2)} | 坐标: ({row}, {col})");
+                }
+            }
+        }
+
+        /// <summary>
+        /// 匈牙利算法实现 (最小权重指派)
+        /// </summary>
+        private int[] SolveHungarian(double[,] costMatrix, int rows, int cols)
+        {
+            int[] match = new int[cols];
+            for (int i = 0; i < cols; i++) match[i] = -1;
+
+            double[] lx = new double[rows]; // 左集合顶标
+            double[] ly = new double[cols]; // 右集合顶标
+
+            // 初始化顶标：左集合顶标设为该行最小值，右集合为0
+            for (int i = 0; i < rows; i++)
+            {
+                lx[i] = double.MaxValue;
+                for (int j = 0; j < cols; j++)
+                    if (costMatrix[i, j] < lx[i]) lx[i] = costMatrix[i, j];
+            }
+
+            for (int i = 0; i < rows; i++)
+            {
+                while (true)
+                {
+                    bool[] vx = new bool[rows];
+                    bool[] vy = new bool[cols];
+                    double[] slack = new double[cols];
+                    for (int k = 0; k < cols; k++) slack[k] = double.MaxValue;
+
+                    if (DfsHungarian(i, vx, vy, lx, ly, costMatrix, match, slack, rows, cols)) break;
+
+                    // 如果无法匹配，修改顶标
+                    double d = double.MaxValue;
+                    for (int j = 0; j < cols; j++)
+                        if (!vy[j] && slack[j] < d) d = slack[j];
+
+                    if (d == double.MaxValue) break; // 理论上不会发生
+
+                    for (int j = 0; j < rows; j++) if (vx[j]) lx[j] += d;
+                    for (int j = 0; j < cols; j++)
+                    {
+                        if (vy[j]) ly[j] -= d;
+                        else slack[j] -= d;
+                    }
+                }
+            }
+
+            // 返回结果：英雄索引 -> 格子索引
+            int[] result = new int[rows];
+            for (int i = 0; i < rows; i++) result[i] = -1;
+            for (int j = 0; j < cols; j++)
+                if (match[j] != -1) result[match[j]] = j;
+
+            return result;
+        }
+
+        private bool DfsHungarian(int u, bool[] vx, bool[] vy, double[] lx, double[] ly, double[,] cost, int[] match, double[] slack, int rows, int cols)
+        {
+            vx[u] = true;
+            for (int v = 0; v < cols; v++)
+            {
+                if (vy[v]) continue;
+                double diff = cost[u, v] - (lx[u] + ly[v]);
+                if (Math.Abs(diff) < 1e-7) // 相等子图
+                {
+                    vy[v] = true;
+                    if (match[v] == -1 || DfsHungarian(match[v], vx, vy, lx, ly, cost, match, slack, rows, cols))
+                    {
+                        match[v] = u;
+                        return true;
+                    }
+                }
+                else
+                {
+                    if (slack[v] > diff) slack[v] = diff;
+                }
+            }
+            return false;
+        }
+        #endregion
+    }
+}

--- a/SourceCode/JinChanChanTool/Services/Network/HttpProvider.cs
+++ b/SourceCode/JinChanChanTool/Services/Network/HttpProvider.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Net.Http;
+
+namespace JinChanChanTool.Services.Network
+{
+    /// <summary>
+    /// 通过连接复用解决 SSL 握手异常，并支持高并发请求
+    /// </summary>
+    public static class HttpProvider
+    {
+        private static readonly HttpClient _instance;
+
+        static HttpProvider()
+        {
+            var handler = new SocketsHttpHandler
+            {
+                //  允许连接长期存活，确保高并发时能充分复用已建立的 SSL 隧道
+                PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+
+                // 设置标准的闲置超时，30秒内无请求才会回收连接
+                PooledConnectionIdleTimeout = TimeSpan.FromSeconds(30),
+
+                // 提升单服务器最大连接上限
+                // 这样在多个英雄请求迸发时，底层的 Socket 管道更充裕
+                MaxConnectionsPerServer = 50
+            };
+
+            _instance = new HttpClient(handler)
+            {
+                // 设置合理的超时，防止个别请求卡死全局流程
+                Timeout = TimeSpan.FromSeconds(30)
+            };
+
+            _instance.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+        }
+
+        public static HttpClient Client => _instance;
+    }
+}

--- a/SourceCode/JinChanChanTool/Services/RecommendedEquipment/DynamicGameDataService.cs
+++ b/SourceCode/JinChanChanTool/Services/RecommendedEquipment/DynamicGameDataService.cs
@@ -1,5 +1,7 @@
-﻿using JinChanChanTool.Forms;
+﻿using JinChanChanTool.DataClass;
+using JinChanChanTool.Forms;
 using JinChanChanTool.Services.RecommendedEquipment.Interface;
+using JinChanChanTool.Services.Network;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -13,78 +15,76 @@ namespace JinChanChanTool.Services.RecommendedEquipment
 {
     /// <summary>
     /// 实现了 IDynamicGameDataService 接口。
-    /// 这个服务通过网络API获取动态的游戏数据，如翻译文件和英雄列表，
-    /// 并将处理后的结果缓存在内存中，供应用程序的其他部分使用。
+    /// 改为使用全局 HttpProvider 管理的 HttpClient。
     /// </summary>
     public class DynamicGameDataService : IDynamicGameDataService
     {
-        // 定义数据源的URL常量，便于管理和修改
         private const string TranslationsUrl = "https://data.metatft.com/lookups/TFTSet16_pbe_zh_cn.json";
         private const string UnitListUrl = "https://api-hc.metatft.com/tft-comps-api/unit_items_processed";
+        private const string GeneralTranslationsUrl = "https://data.metatft.com/locales/zh_cn.json";
 
-        // 遵循最佳实践，在整个应用程序生命周期内共享一个HttpClient实例，以提高性能和避免套接字耗尽问题。
-        private static readonly HttpClient _httpClient = new HttpClient();
+        // 删除了本地 static readonly HttpClient _httpClient 实例
 
-        // 状态标记，防止重复执行昂贵的初始化网络请求。
         private bool _isInitialized = false;
 
         #region IDynamicGameDataService 实现
 
         public Dictionary<string, string> HeroTranslations { get; private set; }
         public Dictionary<string, string> ItemTranslations { get; private set; }
+        public Dictionary<string, string> TraitTranslations { get; private set; }
+        public Dictionary<string, string> CommonTranslations { get; private set; }
         public List<string> CurrentSeasonHeroKeys { get; private set; }
 
         #endregion
 
-        /// <summary>
-        /// 构造函数，初始化所有集合属性，确保它们在使用前不为null。
-        /// </summary>
         public DynamicGameDataService()
         {
             HeroTranslations = new Dictionary<string, string>();
             ItemTranslations = new Dictionary<string, string>();
+            TraitTranslations = new Dictionary<string, string>();
+            CommonTranslations = new Dictionary<string, string>();
             CurrentSeasonHeroKeys = new List<string>();
         }
 
         /// <summary>
         /// 异步初始化服务，从网络加载所有必需的数据。
-        /// 这个方法是幂等的，即多次调用也只会执行一次实际的数据加载。
         /// </summary>
         public async Task InitializeAsync()
         {
-            if (_isInitialized)
-            {
-                return; // 如果已经初始化，则直接返回，避免重复工作。
-            }
+            if (_isInitialized) return;
 
             try
-            {                
-                Debug.WriteLine("DynamicGameDataService: 开始初始化，准备从网络获取数据...");
-                LogTool.Log("DynamicGameDataService: 开始初始化，准备从网络获取数据...");
-                OutputForm.Instance.WriteLineOutputMessage("DynamicGameDataService: 开始初始化，准备从网络获取数据...");
-                // 使用 Task.WhenAll 并行发起两个网络请求，可以显著缩短总等待时间。
-                var translationTask = _httpClient.GetStringAsync(TranslationsUrl);
-                var unitListTask = _httpClient.GetStringAsync(UnitListUrl);
+            {
+                Debug.WriteLine("DynamicGameDataService: 开始初始化...");
+                LogTool.Log("DynamicGameDataService: 开始初始化...");
+                OutputForm.Instance.WriteLineOutputMessage("DynamicGameDataService: 开始初始化...");
 
-                await Task.WhenAll(translationTask, unitListTask);
+                var translationTask = HttpProvider.Client.GetAsync(TranslationsUrl, HttpCompletionOption.ResponseContentRead);
+                var unitListTask = HttpProvider.Client.GetAsync(UnitListUrl, HttpCompletionOption.ResponseContentRead);
+                var generalTask = HttpProvider.Client.GetAsync(GeneralTranslationsUrl, HttpCompletionOption.ResponseContentRead);
 
-                // 从完成的任务中获取JSON字符串结果
-                string translationJson = await translationTask;
-                string unitListJson = await unitListTask;
+                await Task.WhenAll(translationTask, unitListTask, generalTask);
 
-                // 按顺序处理数据，先处理英雄列表以确定当前赛季
-                ProcessUnitListData(unitListJson);
-                ProcessTranslationData(translationJson);
+                // 获取结果后立即 Dispose 响应对象
+                using var res1 = await translationTask;
+                using var res2 = await unitListTask;
+                using var res3 = await generalTask;
 
-                _isInitialized = true; // 标记初始化成功
+                res1.EnsureSuccessStatusCode();
+                res2.EnsureSuccessStatusCode();
+                res3.EnsureSuccessStatusCode();
+
+                ProcessUnitListData(await res2.Content.ReadAsStringAsync());
+                ProcessTranslationData(await res1.Content.ReadAsStringAsync());
+                ProcessGeneralTranslationData(await res3.Content.ReadAsStringAsync());
+
+                _isInitialized = true;
                 Debug.WriteLine("DynamicGameDataService: 初始化成功！");
                 LogTool.Log("DynamicGameDataService: 初始化成功！");
                 OutputForm.Instance.WriteLineOutputMessage("DynamicGameDataService: 初始化成功！");
             }
             catch (Exception ex)
             {
-                // 如果在初始化过程中发生任何错误（如网络问题、JSON解析失败），记录错误并重新抛出。
-                // 让上层调用者（如应用程序启动逻辑）知道初始化失败，并据此决定如何响应（例如，向用户显示错误消息）。
                 Debug.WriteLine($"DynamicGameDataService: 初始化失败! 错误: {ex.Message}");
                 LogTool.Log($"DynamicGameDataService: 初始化失败! 错误: {ex.Message}");
                 OutputForm.Instance.WriteLineOutputMessage($"DynamicGameDataService: 初始化失败! 错误: {ex.Message}");
@@ -93,8 +93,25 @@ namespace JinChanChanTool.Services.RecommendedEquipment
         }
 
         /// <summary>
-        /// 解析从 unit_items_processed API 获取的JSON数据，提取当前赛季的英雄列表。
+        /// 解析通用翻译JSON，提取 common 节点下的标签翻译。
         /// </summary>
+        private void ProcessGeneralTranslationData(string json)
+        {
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var data = JsonSerializer.Deserialize<MetatftGeneralTranslation>(json, options);
+
+            if (data == null || data.Common == null)
+            {
+                throw new InvalidOperationException("未能正确解析通用翻译数据(zh_cn.json)或数据格式无效。");
+            }
+
+            CommonTranslations = data.Common;
+
+            Debug.WriteLine($"已加载 {CommonTranslations.Count} 条通用标签翻译。");
+            LogTool.Log($"已加载 {CommonTranslations.Count} 条通用标签翻译。");
+            OutputForm.Instance.WriteLineOutputMessage($"已加载 {CommonTranslations.Count} 条通用标签翻译。");
+        }
+
         private void ProcessUnitListData(string json)
         {
             var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
@@ -105,56 +122,49 @@ namespace JinChanChanTool.Services.RecommendedEquipment
                 throw new InvalidOperationException("未能正确解析英雄列表数据或数据格式无效。");
             }
 
-            // 从 "TFTSet15" 中推断出赛季前缀 "TFT15"
             string seasonPrefix = unitListResponse.TftSet.Replace("Set", "");
 
-            // 筛选出所有以当前赛季前缀开头的英雄API Key
             CurrentSeasonHeroKeys = unitListResponse.Units.Keys
                 .Where(key => key.StartsWith(seasonPrefix, StringComparison.OrdinalIgnoreCase))
                 .ToList();
-            
+
             Debug.WriteLine($"已确定当前赛季: {seasonPrefix}，找到 {CurrentSeasonHeroKeys.Count} 位英雄。");
             LogTool.Log($"已确定当前赛季: {seasonPrefix}，找到 {CurrentSeasonHeroKeys.Count} 位英雄。");
             OutputForm.Instance.WriteLineOutputMessage($"已确定当前赛季: {seasonPrefix}，找到 {CurrentSeasonHeroKeys.Count} 位英雄。");
         }
 
-        /// <summary>
-        /// 解析翻译JSON数据，填充英雄和装备的翻译字典。
-        /// </summary>
         private void ProcessTranslationData(string json)
         {
             var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
             var translationData = JsonSerializer.Deserialize<TranslationData>(json, options);
 
-            if (translationData == null || translationData.Units == null || translationData.Items == null)
+            if (translationData == null || translationData.Units == null ||translationData.Items == null || translationData.Traits == null)
             {
                 throw new InvalidOperationException("未能正确解析翻译数据或数据格式无效。");
             }
 
-            // 增加对重复Key的处理 
-            // 直接 .ToDictionary()
-            // 先按 ApiName 分组 (GroupBy)，然后从每个分组中取第一个元素 (.First()) 来创建字典。
-            // 这样即使源文件有重复的ApiName，也只会取第一个，从而避免了“Key已存在”的错误。
             HeroTranslations = translationData.Units
                 .Where(unit => !string.IsNullOrEmpty(unit.ApiName) && !string.IsNullOrEmpty(unit.Name))
-                .GroupBy(unit => unit.ApiName) // 按ApiName分组
-                .ToDictionary(g => g.Key, g => g.First().Name); // 使用分组的Key和该分组的第一个元素的Name来创建字典
+                .GroupBy(unit => unit.ApiName)
+                .ToDictionary(g => g.Key, g => g.First().Name);
 
             ItemTranslations = translationData.Items
                 .Where(item => !string.IsNullOrEmpty(item.ApiName) && !string.IsNullOrEmpty(item.Name))
-                .GroupBy(item => item.ApiName) // 对装备列表也进行同样的分组去重
+                .GroupBy(item => item.ApiName)
                 .ToDictionary(g => g.Key, g => g.First().Name);
-            
-            Debug.WriteLine($"已加载 {HeroTranslations.Count} 条英雄翻译和 {ItemTranslations.Count} 条装备翻译。");
-            LogTool.Log($"已加载 {HeroTranslations.Count} 条英雄翻译和 {ItemTranslations.Count} 条装备翻译。");
-            OutputForm.Instance.WriteLineOutputMessage($"已加载 {HeroTranslations.Count} 条英雄翻译和 {ItemTranslations.Count} 条装备翻译。");
+
+            TraitTranslations = translationData.Traits
+                .Where(trait => !string.IsNullOrEmpty(trait.ApiName) && !string.IsNullOrEmpty(trait.Name))
+                .GroupBy(trait => trait.ApiName)
+                .ToDictionary(g => g.Key, g => g.First().Name);
+
+            Debug.WriteLine($"已加载 {HeroTranslations.Count} 条英雄翻译、{ItemTranslations.Count} 条装备翻译和 {TraitTranslations.Count} 条羁绊翻译。");
+            LogTool.Log($"已加载 {HeroTranslations.Count} 条英雄翻译、{ItemTranslations.Count} 条装备翻译和 {TraitTranslations.Count} 条羁绊翻译。");
+            OutputForm.Instance.WriteLineOutputMessage($"已成功加载全量翻译数据（含 {TraitTranslations.Count} 条羁绊）。");
         }
 
         #region 内部数据模型
 
-        /// <summary>
-        /// 用于反序列化 unit_items_processed API 响应的内部模型。
-        /// </summary>
         private class UnitListResponse
         {
             [JsonPropertyName("tft_set")]

--- a/SourceCode/JinChanChanTool/Services/RecommendedEquipment/Interface/IDynamicGameDataService.cs
+++ b/SourceCode/JinChanChanTool/Services/RecommendedEquipment/Interface/IDynamicGameDataService.cs
@@ -5,34 +5,36 @@ namespace JinChanChanTool.Services.RecommendedEquipment.Interface
 {
     /// <summary>
     /// 为动态游戏数据服务定义接口。
-    /// 该服务负责从网络获取、处理并提供最新的游戏数据，
-    /// 例如英雄列表、装备翻译等，取代了旧的基于本地文件的 IApiRequestPayloadDataService。
     /// </summary>
     public interface IDynamicGameDataService
     {
         /// <summary>
         /// 获取一个字典，其中包含英雄API Key到中文名的映射。
-        /// 在调用 InitializeAsync() 成功后，此属性将被填充。
         /// </summary>
         Dictionary<string, string> HeroTranslations { get; }
 
         /// <summary>
         /// 获取一个字典，其中包含装备API Key到中文名的映射。
-        /// 在调用 InitializeAsync() 成功后，此属性将被填充。
         /// </summary>
         Dictionary<string, string> ItemTranslations { get; }
 
         /// <summary>
+        /// 获取一个字典，其中包含羁绊API Key到中文名的映射。
+        /// </summary>
+        Dictionary<string, string> TraitTranslations { get; }
+
+        /// <summary>
+        /// 获取一个字典，其中包含通用标签（如难度、经济类型）的映射。
+        /// </summary>
+        Dictionary<string, string> CommonTranslations { get; }
+
+        /// <summary>
         /// 获取一个列表，其中包含当前赛季所有英雄的API Key。
-        /// 在调用 InitializeAsync() 成功后，此属性将被填充。
         /// </summary>
         List<string> CurrentSeasonHeroKeys { get; }
 
         /// <summary>
         /// 异步初始化服务。
-        /// 此方法会从网络上拉取所有必需的游戏数据（翻译、英雄列表等），
-        /// 并填充此接口暴露的各个属性。
-        /// 应该在应用程序启动时调用一次。
         /// </summary>
         /// <returns>一个表示异步操作的 Task。</returns>
         Task InitializeAsync();

--- a/SourceCode/JinChanChanTool/Services/RecommendedEquipment/TranslationModels.cs
+++ b/SourceCode/JinChanChanTool/Services/RecommendedEquipment/TranslationModels.cs
@@ -28,6 +28,12 @@ namespace JinChanChanTool.Services.RecommendedEquipment
         /// </summary>
         [JsonPropertyName("items")]
         public List<TranslationEntry> Items { get; set; }
+
+        /// <summary>
+        /// 包含所有羁绊翻译信息的列表。
+        /// </summary>
+        [JsonPropertyName("traits")]
+        public List<TranslationEntry> Traits { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
…任何服务直接获取该实例，而无需在 Program.cs 中进行初始化，重构DynamicGameDataService以及CrawlingService，删除它们拥有的HttpClient 定义，统一调用全局 HttpProvider 的实例

提升阵容推荐以及装备推荐爬取速度